### PR TITLE
Fix fly.io script to first build the request library

### DIFF
--- a/authorization-server/jwt-authorization-grant.js
+++ b/authorization-server/jwt-authorization-grant.js
@@ -1,8 +1,8 @@
+import { OAuthGrantType } from 'id-assert-authz-grant-client';
 import * as jose from 'jose';
 import { CustomOIDCProviderError } from 'oidc-provider/lib/helpers/errors.js';
 import validatePresence from 'oidc-provider/lib/helpers/validate_presence.js';
 import instance from 'oidc-provider/lib/helpers/weak_cache.js';
-import { OAuthGrantType } from 'id-assert-authz-grant-client';
 import makeConfiguration from './server-configuration.js';
 import { validateSignatureJWKs } from './utils/jwks.js';
 

--- a/deployment/app.fly.dockerfile
+++ b/deployment/app.fly.dockerfile
@@ -29,6 +29,7 @@ COPY yarn.lock yarn.lock
 COPY deployment deployment
 COPY id-assert-authz-grant-client id-assert-authz-grant-client
 
+RUN yarn preinstall
 RUN yarn install
 RUN yarn build:todo
 RUN yarn build:wiki

--- a/deployment/auth.fly.dockerfile
+++ b/deployment/auth.fly.dockerfile
@@ -26,5 +26,6 @@ COPY yarn.lock yarn.lock
 COPY deployment deployment
 COPY id-assert-authz-grant-client id-assert-authz-grant-client
 
+RUN yarn preinstall
 RUN cd authorization-server && yarn install
 ENTRYPOINT ./deployment/start-auth.sh


### PR DESCRIPTION
This was previously working because docker was copying files from my local machine.  The long term solution will be to deploy from CI where the folder would be clean before deploying.