### PR TITLE
Fix cli command in github workflows

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,4 +1,4 @@
-ame: Fly Deploy
+name: Fly Deploy
 on:
   release:
     types: [published]


### PR DESCRIPTION
Accidentally used symlink command in the github workflow which is not available.

Remove the push even trigger for now until workflows is working properly. We may also want to separate auth server changes to a sep. job