### PR TITLE
Fixes dev containers connecting to other services on the host.

### DIFF
--- a/.devcontainer/.env.default
+++ b/.devcontainer/.env.default
@@ -1,0 +1,1 @@
+IDENTITY_PROVIDER_HOST=your.identity.domain.path.com

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,8 +30,8 @@
         "typescript.referencesCodeLens.enabled": true,
         "typescript.implementationsCodeLens.enabled": true,
         "editor.codeActionsOnSave": {
-          "source.organizeImports": true,
-          "source.fixAll": true
+          "source.organizeImports": "always",
+          "source.fixAll": "always"
         },
         "editor.formatOnSave": true,
         "typescript.format.semicolons": "insert",
@@ -40,8 +40,6 @@
       }
     }
   },
-  // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  // "forwardPorts": [3000, 27017],
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "yarn install && yarn postinstall"
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,7 +15,6 @@ services:
 
     network_mode: host
     extra_hosts:
-      - 'rain.okta1.com:host-gateway'
       - 'dev-redis:172.20.0.3'
       - 'dev-db:172.20.0.2'
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,6 +15,7 @@ services:
 
     network_mode: host
     extra_hosts:
+      - '${IDENTITY_PROVIDER_HOST:-localhost}:host-gateway'
       - 'dev-redis:172.20.0.3'
       - 'dev-db:172.20.0.2'
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,11 +13,15 @@ services:
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
 
-    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:db
+    network_mode: host
+    extra_hosts:
+      - 'rain.okta1.com:host-gateway'
+      - 'dev-redis:172.20.0.3'
+      - 'dev-db:172.20.0.2'
 
-    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
+    depends_on:
+      - db
+      - redis
 
   db:
     image: mariadb:latest
@@ -26,11 +30,22 @@ services:
     restart: unless-stopped
     volumes:
       - mysqldata:/var/lib/mysql
+    networks:
+      devcontainer-network:
+        ipv4_address: 172.20.0.2
   redis:
     image: redis:latest
     restart: unless-stopped
-    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:db
+    networks:
+      devcontainer-network:
+        ipv4_address: 172.20.0.3
+
+networks:
+  devcontainer-network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16
 
 volumes:
   mysqldata:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,5 @@
 nodeLinker: node-modules
 
-npmRegistryServer: "https://registry.yarnpkg.com"
+npmRegistryServer: 'https://registry.yarnpkg.com'
 
 yarnPath: .yarn/releases/yarn-4.2.2.cjs

--- a/local-development/docker-compose.yml
+++ b/local-development/docker-compose.yml
@@ -24,18 +24,18 @@ services:
     volumes:
       - mysqldata:/var/lib/mysql
     ports:
-      - "127.0.0.1:3306:3306"
+      - '127.0.0.1:3306:3306'
     expose:
-    - "127.0.0.1:3306"
+      - '127.0.0.1:3306'
   redis:
     image: redis:latest
     restart: unless-stopped
     # # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
     # network_mode: service:db
     ports:
-      - "127.0.0.1:6379:6379"
+      - '127.0.0.1:6379:6379'
     expose:
-    - "127.0.0.1:6379"
+      - '127.0.0.1:6379'
 
 volumes:
   mysqldata:

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "setup:env": "node scripts/setup-env.js",
     "bootstrap": "node scripts/bootstrap.js",
-    "dev:all": "concurrently --names \"wiki,auth-wiki,todo,auth-todo\" --prefix-colors \"blue,magenta,green,red\" --output-path logs/dev-all.log \"yarn dev:wiki\" \"yarn auth:wiki\" \"yarn dev:todo\" \"yarn auth:todo\"",
-    "open:apps": "node scripts/open-apps.js"
+    "dev:all": "concurrently --names \"wiki,auth-wiki,todo,auth-todo\" --prefix-colors \"blue,magenta,green,red\" --output-path logs/dev-all.log \"yarn dev:wiki\" \"yarn auth:wiki\" \"yarn dev:todo\" \"yarn auth:todo\""
   },
   "author": "",
   "license": "ISC",

--- a/packages/authorization-server/.env.wiki.default
+++ b/packages/authorization-server/.env.wiki.default
@@ -2,7 +2,7 @@ AUTH_SERVER_PORT="5000"
 AUTH_SERVER="http://localhost:5000"
 COOKIE_SECRET="secret"
 AUTH_INTERACTION_COOKIE_SECRET="secret key one"
-REDIS_SERVER="redis://localhost:6379"
+REDIS_SERVER="redis://dev-redis:6379"
 # The resource server that uses this AS
 APP_RESOURCE="http://localhost:3000/"
 

--- a/packages/todo0/.env.default
+++ b/packages/todo0/.env.default
@@ -4,7 +4,7 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-TODO_DATABASE_URL="mysql://root:avocado@localhost:3306/todo"
+TODO_DATABASE_URL="mysql://root:avocado@dev-db:3306/todo"
 COOKIE_SECRET="secret"
 
 AUTH_SERVER="http://localhost:5001"
@@ -13,4 +13,4 @@ TODO_SERVER="http://localhost:3001"
 CLIENT1_CLIENT_ID="todo0"
 CLIENT1_CLIENT_SECRET="secret"
 
-REDIS_SERVER="redis://localhost:6379"
+REDIS_SERVER="redis://dev-redis:6379"

--- a/packages/wiki0/.env.default
+++ b/packages/wiki0/.env.default
@@ -4,7 +4,7 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-WIKI_DATABASE_URL="mysql://root:avocado@localhost:3306/wiki"
+WIKI_DATABASE_URL="mysql://root:avocado@dev-db:3306/wiki"
 COOKIE_SECRET="secret"
 
 AUTH_SERVER="http://localhost:5000"
@@ -17,6 +17,6 @@ CLIENT1_CLIENT_SECRET="secret"
 TODO_SERVER="http://localhost:3001"
 TODO_AUTH_SERVER="http://localhost:5001"
 
-REDIS_SERVER="redis://localhost:6379"
+REDIS_SERVER="redis://dev-redis:6379"
 CLIENT2_CLIENT_ID="wiki0-at-todo0"
 CLIENT2_CLIENT_SECRET="secret-todo"


### PR DESCRIPTION
### Summary

* Moves redis/db to their own internal IP to avoid conflict with host docker.
* Updates env vars to point to those DNSs
* Cleans up devcontainers json file
* Adds `IDENTITY_PROVIDER_HOST` which can be used for custom domain resolved identity URL (where `localhost` isn't good enough, and your identity provider is on your host machine, or another bridged docker).